### PR TITLE
action: add option to disable apt-cacher

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,27 @@ The requested operating system and architecture combination is not available in 
 **Resolution:**
 Confirm that the specified OS and architecture are supported by **image-garden**, and update your inputs as needed.
 
+### Trouble accessing repositories using `apt`
+
+**Cause:**
+Image-garden bundles **apt-cacher-ng**, which acts as a caching proxy for apt
+repositories. This improves performance by caching downloaded packages across
+workflow runs, but may mask issues related to accessing said repositories in
+environments with strict policies for outgoing network connections.
+
+**Resolution:**
+Disable apt-cacher-ng by setting the `cache-deb-packages` input to `false` in your workflow:
+
+```yaml
+- name: Run integration tests
+  uses: zyga/image-garden-action@v0
+  with:
+    garden-system: debian-cloud-12
+    cache-deb-packages: "false"
+```
+
+This will stop the apt-cacher-ng service and remove its socket, allowing direct access to apt repositories.
+
 ## Further reading
 
 Consult documentation of [spread](https://github.com/canonical/spread) and

--- a/action.yaml
+++ b/action.yaml
@@ -21,6 +21,9 @@ inputs:
     cache-prepared-images:
         description: Use GitHub cache to store project-specific images (cache-intensive, scales poorly with number of systems)
         default: "false"
+    cache-deb-packages:
+        description: Use apt-cacher for caching deb packages
+        default: "true"
     spread-variant:
         description: Variant of spread to use
         default: ""
@@ -132,6 +135,14 @@ runs:
           shell: bash
           if: ${{ inputs.spread-variant != '' }}
           run: sudo snap set image-garden spread-variant=${{ inputs.spread-variant }}
+        - name: Disable apt-cacher-ng
+          shell: bash
+          if: ${{ !fromJSON(inputs.cache-deb-packages) }}
+          run: |
+            echo "::group::Disable apt-cacher-ng"
+            sudo snap stop image-garden.apt-cacher-ng
+            sudo rm -fv /var/snap/image-garden/common/apt-cacher-ng.sock
+            echo "::endgroup::"
         - name: Make the virtual machine image (dry run)
           shell: bash
           working-directory: ${{ inputs.spread-subdir }}


### PR DESCRIPTION
Add an option to disable (stop actually) apt-cacher-ng before running the test. Make sure the socket is cleaned up so that image-garden would not pick it up and try to setup proxing.